### PR TITLE
Rollback Analytify Plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "wpackagist-plugin/breadcrumb-trail": "*",
         "ministryofjustice/wp-rewrite-media-to-s3": "*",
         "wpackagist-plugin/menu-icons": "*",
-        "wpackagist-plugin/wp-analytify":"*",
+        "wpackagist-plugin/wp-analytify":"4.2.2",
         "wpackagist-plugin/analytify-analytics-dashboard-widget":"*",
         "wpackagist-plugin/classic-editor": "*",
         "ministryofjustice/wp-moj-components": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d87f4e5fa3631f827eb81985276fe03",
+    "content-hash": "554f223f931d3a46276ed0ac2cf7e1bb",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -1751,15 +1751,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-analytify",
-            "version": "5.0.0",
+            "version": "4.2.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-analytify/",
-                "reference": "tags/5.0.0"
+                "reference": "tags/4.2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-analytify.5.0.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-analytify.4.2.2.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
Latest Analytify plugin conflicts with Notify Plugin as both use guzzle. We should look to remove Analytify plugin anyway as we should be using GTM.